### PR TITLE
Add Firefox support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,9 @@
 {
+  "applications": {
+    "gecko": {
+      "id": "FANDOM-d-import@addon"
+    }
+  },
   "name": "Customize Discussions",
   "version": "1.0",
   "description": "Imports custom JavaScript and CSS into all Discussions on FANDOM",

--- a/options.html
+++ b/options.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head><title>Customize Discussions</title></head>
-<body style="width:500px; height:200px; font-size:12px;">
+<body style="min-width:500px; min-height:200px; font-size:12px">
 <h2>JavaScript</h2>
 Import style
 <select id="importChoice-JS">
@@ -25,7 +25,7 @@ Import style
 If you have picked option #2, please specify:
 <br>Wiki URL (please follow format): <input type="text" id="other-CSS.wiki" placeholder="https://community.wikia.com">
 <br>Page name: <input type="text" id="other-CSS.page" placeholder="User:Jr Mime/gDiscussions.css">
-<div id="status"></div>
+<div id="status" style="margin-top:10px"></div>
 <button id="save">Save</button>
 
 <script src="options.js"></script>


### PR DESCRIPTION
Adds Firefox support. Code is fully compatible, only extension ID is required by Firefox to use `storage.sync`. I also added small fix for options menu, so it'll display properly in Firefox.