### PR TITLE
Domain and custom import fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Customize Discussions
-Imports custom JavaScript and CSS into all Discussions on [FANDOM](https://c.wikia.com) via a Chrome/Firefox Extension. Documentation is available [here](https://dev.wikia.com/CustomizeDiscussions).
+Imports custom JavaScript and CSS into all Discussions on [Fandom](https://c.fandom.com) via a Chrome/Firefox Extension. Documentation is available [here](https://dev.fandom.com/CustomizeDiscussions).

--- a/html/options.html
+++ b/html/options.html
@@ -22,7 +22,7 @@
                 </p>
                 <p class="js-other">
                     <label for="js-other-wiki">Wiki URL (please follow format):</label>
-                    <input type="text" name="js-other-wiki" id="js-other-wiki" placeholder="https://community.wikia.com" />
+                    <input type="text" name="js-other-wiki" id="js-other-wiki" placeholder="https://community.fandom.com" />
                 </p>
                 <p class="js-other">
                     <label for="js-other-page">Page name:</label>
@@ -40,7 +40,7 @@
                 </p>
                 <p class="css-other">
                     <label for="css-other-wiki">Wiki URL (please follow format):</label>
-                    <input type="text" name="css-other-wiki" id="css-other-wiki" placeholder="https://community.wikia.com" />
+                    <input type="text" name="css-other-wiki" id="css-other-wiki" placeholder="https://community.fandom.com" />
                 </p>
                 <p class="css-other">
                     <label for="css-other-page">Page name:</label>

--- a/js/import.js
+++ b/js/import.js
@@ -7,7 +7,7 @@
     var DEFAULTS = {
         css: 'Special:MyPage/globalDiscussions.css',
         js: 'Special:MyPage/globalDiscussions.javascript',
-        wiki: 'https://community.wikia.com'
+        wiki: 'https://community.fandom.com'
     }, TYPES = ['js', 'css'], JS_PAGES = [
         DEFAULTS.js,
         'Special:MyPage/globalDiscussions.css',
@@ -24,7 +24,7 @@
     function importJS(prefs) {
         var page = JS_PAGES[prefs.type],
             url = (page ? DEFAULTS : prefs).wiki;
-        url += '/index.php?title=' + encodeURIComponent(page) +
+        url += '/index.php?title=' + encodeURIComponent(page || prefs.page) +
                '&action=raw&ctype=text/javascript';
         importJSByURL('https://code.jquery.com/jquery-3.3.1.min.js');
         importJSByURL(url);
@@ -66,7 +66,7 @@
         TYPES.forEach(function(type) {
             prefs[type + '-type'] = 0;
             prefs[type + '-wiki'] = DEFAULTS.wiki;
-            prefs[type + '-page'] = DEFAULTS.page;
+            prefs[type + '-page'] = DEFAULTS[type];
         });
         chrome.storage.sync.get(prefs, preferences);
     }

--- a/js/options.js
+++ b/js/options.js
@@ -12,7 +12,7 @@
     var DEFAULTS = {
         css: 'Special:MyPage/globalDiscussions.css',
         js: 'Special:MyPage/globalDiscussions.javascript',
-        wiki: 'https://community.wikia.com'
+        wiki: 'https://community.fandom.com'
     }, TYPES = ['js', 'css'];
 
     /**

--- a/manifest.json
+++ b/manifest.json
@@ -5,14 +5,14 @@
         }
     },
     "name": "Customize Discussions",
-    "version": "1.2",
-    "description": "Imports custom JavaScript and CSS into all Discussions on FANDOM",
+    "version": "1.3",
+    "description": "Imports custom JavaScript and CSS into all Discussions on Fandom",
     "content_scripts": [
         {
             "run_at" :"document_end",
             "matches": [
-                "*://*.wikia.com/d*",
-                "*://*.fandom.com/d*"
+                "*://*.fandom.com/d*",
+                "*://*.fandom.com/f*"
             ],
             "js": [
                 "js/import.js"


### PR DESCRIPTION
- All instances of `wikia` have been changed to `fandom`, and `FANDOM` to `Fandom`.
- The extension didn't work on `/f` pages because only `/d` is in the manifest (now `/f` is in the manifest as well).
- Importing pages on custom wiki URLs didn't work (now it does).
- Bumped version.